### PR TITLE
Fix CAN bridge

### DIFF
--- a/src/can-driver/src/uc_stm32_can.cpp
+++ b/src/can-driver/src/uc_stm32_can.cpp
@@ -327,7 +327,7 @@ int CanIface::init(uavcan::uint32_t bitrate)
         goto leave;
     }
 
-    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ;  // RM page 648
+    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ | bxcan::MCR_TXFP;  // RM page 648
 
     can_->BTR = ((timings.sjw & 3U)  << 24) |
                 ((timings.bs1 & 15U) << 16) |

--- a/src/can_bridge.c
+++ b/src/can_bridge.c
@@ -11,7 +11,7 @@ THD_WORKING_AREA(wa_can_bridge, CAN_BRIDGE_STACKSIZE);
 #define CAN_BRIDGE_TX_STACKSIZE 1024
 
 #define CAN_BRIDGE_RX_QUEUE_SIZE    32
-#define CAN_BRIDGE_TX_QUEUE_SIZE    32
+#define CAN_BRIDGE_TX_QUEUE_SIZE    512
 
 memory_pool_t can_bridge_rx_pool;
 memory_pool_t can_bridge_tx_pool;
@@ -22,8 +22,7 @@ SEMAPHORE_DECL(can_bridge_is_initialized, 0);
 msg_t rx_mbox_buf[CAN_BRIDGE_RX_QUEUE_SIZE];
 struct can_frame rx_pool_buf[CAN_BRIDGE_RX_QUEUE_SIZE];
 msg_t tx_mbox_buf[CAN_BRIDGE_TX_QUEUE_SIZE];
-// tx pool size is +1 to be able to block
-struct can_frame tx_pool_buf[CAN_BRIDGE_TX_QUEUE_SIZE + 1];
+struct can_frame tx_pool_buf[CAN_BRIDGE_TX_QUEUE_SIZE];
 
 /** Thread running the CAN bridge. */
 msg_t can_bridge_thread(void *p);

--- a/src/can_bridge.c
+++ b/src/can_bridge.c
@@ -38,6 +38,10 @@ struct can_bridge_instance_t {
 
 void can_bridge_init(void)
 {
+    // default: only standard frames pass the filter
+    can_bridge_filter_id = 0;
+    can_bridge_filter_mask = CAN_FRAME_EXT_FLAG;
+
     // rx queue
     chMBObjectInit(&can_bridge_rx_queue, rx_mbox_buf, CAN_BRIDGE_RX_QUEUE_SIZE);
     chPoolObjectInit(&can_bridge_rx_pool, sizeof(struct can_frame), NULL);

--- a/src/uavcan_node.cpp
+++ b/src/uavcan_node.cpp
@@ -87,8 +87,10 @@ void can_bridge_send_frames(Node& node)
             timeout += uavcan::MonotonicDuration::fromMSec(100);
 
             uavcan::CanSelectMasks masks;
-            masks.write = 1;
-            can.driver.select(masks, timeout);
+            do {
+                masks.write = 1;
+                can.driver.select(masks, timeout);
+            } while (!masks.write & 1 && node.getMonotonicTime() < timeout);
             if (masks.write & 1) {
                 uavcan::MonotonicTime tx_timeout = node.getMonotonicTime();
                 tx_timeout += uavcan::MonotonicDuration::fromMSec(100);


### PR DESCRIPTION
This should address the issues where frames were dropped and reordered.
The fix for reordering changes the hardware TX mailbox setting to FIFO (instead of priority ordering). This is just a temporary fix and should be changed back as soon as I have tested the driver modifications for this issue.
This should also be thoroughly tested, especially how well it runs in parallel with UAVCAN.