### PR TITLE
CAN driver reenable priority reordering.

### DIFF
--- a/src/can-driver/include/uavcan_stm32/can.hpp
+++ b/src/can-driver/include/uavcan_stm32/can.hpp
@@ -175,6 +175,8 @@ public:
      * This is designed for use with iface activity LEDs.
      */
     bool hadActivity();
+
+    bool tx_mb0_is_empty(void);
 };
 
 /**
@@ -223,6 +225,10 @@ public:
      * This is designed for use with iface activity LEDs.
      */
     bool hadActivity();
+
+    // wait for TX mailbox 0 to be empty.
+    // returns true if empty.
+    bool wait_tx_mb0(systime_t timeout);
 };
 
 /**

--- a/src/can-driver/src/uc_stm32_can.cpp
+++ b/src/can-driver/src/uc_stm32_can.cpp
@@ -329,7 +329,7 @@ int CanIface::init(uavcan::uint32_t bitrate)
         goto leave;
     }
 
-    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ | bxcan::MCR_TXFP;  // RM page 648
+    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ;  // RM page 648
 
     can_->BTR = ((timings.sjw & 3U)  << 24) |
                 ((timings.bs1 & 15U) << 16) |

--- a/src/can-driver/src/uc_stm32_can.cpp
+++ b/src/can-driver/src/uc_stm32_can.cpp
@@ -379,7 +379,7 @@ int CanIface::init(uavcan::uint32_t bitrate)
         can_->FMR &= ~bxcan::FMR_FINIT;
     }
 
-    chBSemObjectInit(&tx_mb0_sem, 0);
+    chBSemObjectInit(&tx_mb0_sem, true);
 
 leave:
     return res;
@@ -618,6 +618,7 @@ bool CanIface::tx_mb0_is_empty(void)
 
 bool CanDriver::wait_tx_mb0(systime_t timeout)
 {
+    chBSemReset(&tx_mb0_sem, true);
     if (if0_.tx_mb0_is_empty()) {
         return true;
     }

--- a/src/uavcan_node.cpp
+++ b/src/uavcan_node.cpp
@@ -83,15 +83,7 @@ void can_bridge_send_frames(Node& node)
             ucframe.dlc = framep->dlc;
             memcpy(ucframe.data, framep->data.u8, framep->dlc);
 
-            uavcan::MonotonicTime timeout = node.getMonotonicTime();
-            timeout += uavcan::MonotonicDuration::fromMSec(100);
-
-            uavcan::CanSelectMasks masks;
-            do {
-                masks.write = 1;
-                can.driver.select(masks, timeout);
-            } while (!masks.write & 1 && node.getMonotonicTime() < timeout);
-            if (masks.write & 1) {
+            if (can.driver.wait_tx_mb0(MS2ST(100))) {
                 uavcan::MonotonicTime tx_timeout = node.getMonotonicTime();
                 tx_timeout += uavcan::MonotonicDuration::fromMSec(100);
                 uavcan::ICanIface* const iface = can.driver.getIface(0);


### PR DESCRIPTION
I modified the CAN driver to be able to wait only for one TX mailbox.
This allows reenabling priority ordering of queued CAN frames without having the reordering issue of the CAN bridge frames.