### PR TITLE
Bus enumerator fixes

### DIFF
--- a/src/bus_enumerator.c
+++ b/src/bus_enumerator.c
@@ -19,9 +19,9 @@ static uint16_t index_by_str_id(const bus_enumerator_t *en, const char *str_id)
     while (imax > imin) {
         imid = midpoint(imin, imax);
 
-        if (strncmp(str_id, en->str_to_can[imid].str_id, en->str_id_max_len) == 0) {
+        if (strcmp(str_id, en->str_to_can[imid].str_id) == 0) {
             return imid;
-        } else if (strncmp(str_id, en->str_to_can[imid].str_id, en->str_id_max_len) > 0) {
+        } else if (strcmp(str_id, en->str_to_can[imid].str_id) > 0) {
             imin = imid + 1;
         } else {
             imax = imid;
@@ -51,41 +51,41 @@ static uint16_t index_by_can_id(const bus_enumerator_t *en, uint8_t can_id)
 }
 
 void bus_enumerator_init(bus_enumerator_t *en,
-                         bus_enumerator_entry_t *buffer,
-                         uint16_t buffer_len,
-                         uint8_t str_id_max_len)
+                         struct bus_enumerator_entry_allocator *buffer,
+                         uint16_t buffer_len)
 {
-    en->str_to_can = buffer;
-    en->can_to_str = buffer + buffer_len;
+    en->str_to_can = (bus_enumerator_entry_t*)buffer;
+    en->can_to_str = (bus_enumerator_entry_t*)buffer + buffer_len;
     en->buffer_len = buffer_len;
     en->nb_entries_str_to_can = 0;
     en->nb_entries_can_to_str = 0;
-    en->str_id_max_len = str_id_max_len;
 }
 
 void bus_enumerator_add_node(bus_enumerator_t *en, const char *str_id, void *driver)
 {
-    uint16_t imin = 0, imax = en->nb_entries_str_to_can, imid;
+    if (en->nb_entries_str_to_can < en->buffer_len) {
+        uint16_t imin = 0, imax = en->nb_entries_str_to_can, imid;
 
-    while (imin != imax) {
-        imid = midpoint(imin, imax);
+        while (imin != imax) {
+            imid = midpoint(imin, imax);
 
-        if (strncmp(str_id, en->str_to_can[imid].str_id, en->str_id_max_len) > 0) {
-            imin = imid + 1;
-        } else {
-            imax = imid;
+            if (strcmp(str_id, en->str_to_can[imid].str_id) > 0) {
+                imin = imid + 1;
+            } else {
+                imax = imid;
+            }
         }
+
+        memmove(&en->str_to_can[imin + 1],
+                &en->str_to_can[imin],
+                (en->nb_entries_str_to_can - imin) * sizeof(bus_enumerator_entry_t));
+
+        en->str_to_can[imin].str_id = str_id;
+        en->str_to_can[imin].driver = driver;
+        en->str_to_can[imin].can_id = BUS_ENUMERATOR_CAN_ID_NOT_SET;
+
+        en->nb_entries_str_to_can++;
     }
-
-    memmove(&en->str_to_can[imin + 1],
-            &en->str_to_can[imin],
-            (en->nb_entries_str_to_can - imin) * sizeof(bus_enumerator_entry_t));
-
-    en->str_to_can[imin].str_id = str_id;
-    en->str_to_can[imin].driver = driver;
-    en->str_to_can[imin].can_id = BUS_ENUMERATOR_CAN_ID_NOT_SET;
-
-    en->nb_entries_str_to_can++;
 }
 
 void bus_enumerator_update_node_info(bus_enumerator_t *en, const char *str_id, uint8_t can_id)
@@ -94,7 +94,9 @@ void bus_enumerator_update_node_info(bus_enumerator_t *en, const char *str_id, u
 
     index = index_by_str_id(en, str_id);
 
-    if (index != BUS_ENUMERATOR_INDEX_NOT_FOUND) {
+    if (index != BUS_ENUMERATOR_INDEX_NOT_FOUND &&
+        en->str_to_can[index].can_id == BUS_ENUMERATOR_CAN_ID_NOT_SET) {
+
         // set CAN ID in string_ID->CAN_ID buffer
         en->str_to_can[index].can_id = can_id;
 

--- a/src/bus_enumerator.h
+++ b/src/bus_enumerator.h
@@ -46,13 +46,11 @@ typedef struct {
     uint16_t buffer_len;
     uint16_t nb_entries_str_to_can;
     uint16_t nb_entries_can_to_str;
-    uint8_t str_id_max_len;
 } bus_enumerator_t;
 
 void bus_enumerator_init(bus_enumerator_t *en,
-                         bus_enumerator_entry_t *buffer,
-                         uint16_t buffer_len,
-                         uint8_t str_id_max_len);
+                         struct bus_enumerator_entry_allocator *buffer,
+                         uint16_t buffer_len);
 
 // only a reference of str_id is stored
 void bus_enumerator_add_node(bus_enumerator_t *en, const char *str_id, void *driver);


### PR DESCRIPTION
- assume NULL-terminated strings
- no buffer overflows when adding nodes
- CAN ID can only be changed once