### PR TITLE
linkerscript with core coupled memory section

### DIFF
--- a/rules.ld
+++ b/rules.ld
@@ -1,0 +1,144 @@
+/*
+    ChibiOS - Copyright (C) 2006..2015 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+__ram_start__           = ORIGIN(ram);
+__ram_size__            = LENGTH(ram);
+__ram_end__             = __ram_start__ + __ram_size__;
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    . = 0;
+    _text = .;
+
+    startup : ALIGN(16) SUBALIGN(16)
+    {
+        KEEP(*(vectors))
+    } > flash
+
+    constructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE(__init_array_end = .);
+    } > flash
+
+    destructors : ALIGN(4) SUBALIGN(4)
+    {
+        PROVIDE(__fini_array_start = .);
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        PROVIDE(__fini_array_end = .);
+    } > flash
+
+    .text : ALIGN(16) SUBALIGN(16)
+    {
+        *(.text.startup.*)
+        *(.text)
+        *(.text.*)
+        *(.rodata)
+        *(.rodata.*)
+        *(.glue_7t)
+        *(.glue_7)
+        *(.gcc*)
+    } > flash
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > flash
+
+    .ARM.exidx : {
+        PROVIDE(__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE(__exidx_end = .);
+     } > flash
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > flash
+
+    .eh_frame : ONLY_IF_RO
+    {
+        *(.eh_frame)
+    } > flash
+
+    .textalign : ONLY_IF_RO
+    {
+        . = ALIGN(8);
+    } > flash
+
+    . = ALIGN(4);
+    _etext = .;
+    _textdata = _etext;
+
+    .stacks :
+    {
+        . = ALIGN(8);
+        __main_stack_base__ = .;
+        . += __main_stack_size__;
+        . = ALIGN(8);
+        __main_stack_end__ = .;
+        __process_stack_base__ = .;
+        __main_thread_stack_base__ = .;
+        . += __process_stack_size__;
+        . = ALIGN(8);
+        __process_stack_end__ = .;
+        __main_thread_stack_end__ = .;
+    } > ram
+
+    .data ALIGN(4) : ALIGN(4)
+    {
+        . = ALIGN(4);
+        PROVIDE(_data = .);
+        *(.data)
+        *(.data.*)
+        *(.ramtext)
+        . = ALIGN(4);
+        PROVIDE(_edata = .);
+    } > ram AT > flash
+
+    .bss ALIGN(4) : ALIGN(4)
+    {
+        . = ALIGN(4);
+        PROVIDE(_bss_start = .);
+        *(.bss)
+        *(.bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        PROVIDE(_bss_end = .);
+    } > ram
+
+    .ccm :
+    {
+        . = ALIGN(4);
+        *(.ccm)
+        *(.ccm.*)
+        . = ALIGN(4);
+    } > ccmram
+}
+
+PROVIDE(end = .);
+_end            = .;
+
+__heap_base__   = _end;
+__heap_end__    = __ram_end__;


### PR DESCRIPTION
Note:
- the CPU can not execute code form CCM.
- the CCM can not be used with peripherals like DMA controller (e.g. for most drivers)

usage:
``` C
__attribute__((section(".ccm")))
int my_ccm_buffer[42];
```