### PR TITLE
Stack smashing countermeasures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@
 # Compiler options here.
 ifeq ($(USE_OPT),)
   USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
-  USE_OPT += -fno-stack-protector -ftree-loop-distribute-patterns
   USE_OPT += -frename-registers -freorder-blocks -fconserve-stack
   USE_OPT += -fstack-protector-all -L .
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifeq ($(USE_OPT),)
   USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
   USE_OPT += -fno-stack-protector -ftree-loop-distribute-patterns
   USE_OPT += -frename-registers -freorder-blocks -fconserve-stack
+  USE_OPT += -fstack-protector-all -L .
 endif
 
 # C specific options here (added to USE_OPT).
@@ -242,6 +243,14 @@ GLOBAL_SRC_DEP = app_src.mk
 
 RULESPATH = $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC
 include $(RULESPATH)/rules.mk
+
+# Empty libraries, required by stack smashing protection
+PRE_MAKE_ALL_RULE_HOOK: libssp.a libssp_nonshared.a
+libssp.a:
+	arm-none-eabi-ar rcs $@
+
+libssp_nonshared.a:
+	arm-none-eabi-ar rcs $@
 
 .PHONY: mem_info
 mem_info: build/$(PROJECT).elf

--- a/src/chconf.h
+++ b/src/chconf.h
@@ -438,8 +438,17 @@
  * @brief   Context switch hook.
  * @details This hook is invoked just before switching between threads.
  */
+#if !defined(_FROM_ASM_)
+#ifdef __cplusplus
+extern "C" {
+#endif
+void context_switch_hook(void *ntp, void *otp);
+#ifdef __cplusplus
+}
+#endif
+#endif /* _FROM_ASM_ */
 #define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) {                              \
-  /* System halt code here.*/                                               \
+        context_switch_hook(ntp, otp); \
 }
 
 /**

--- a/src/lwip_bindings/lwipthread.h
+++ b/src/lwip_bindings/lwipthread.h
@@ -33,7 +33,7 @@
 
 /** @brief MAC thread stack size. */
 #if !defined(LWIP_THREAD_STACK_SIZE) || defined(__DOXYGEN__)
-#define LWIP_THREAD_STACK_SIZE              576
+#define LWIP_THREAD_STACK_SIZE              2048
 #endif
 
 /** @brief Link poll interval. */

--- a/src/main.c
+++ b/src/main.c
@@ -207,3 +207,21 @@ void __stack_chk_fail(void)
     chSysHalt("Stack smashing detected");
 }
 
+void context_switch_hook(void *ntp, void *otp)
+{
+    (void) otp;
+
+    /* The main thread does not have the same memory layout as the other ones
+       (it uses the process stack instead of its own stack), so we ignore it. */
+    if (ntp == &ch.mainthread) {
+        return;
+    }
+
+    mpu_configure_region(6,
+                         /* we skip sizeof(thread_t) because the start of the working area is used by ChibiOS. */
+                         ntp + sizeof(thread_t) + 32,
+                         5, /* 32 bytes */
+                         AP_NO_NO, /* no permission */
+                         false);
+
+}

--- a/src/main.c
+++ b/src/main.c
@@ -217,11 +217,14 @@ void context_switch_hook(void *ntp, void *otp)
         return;
     }
 
+    chSysLockFromISR();
+
     mpu_configure_region(6,
                          /* we skip sizeof(thread_t) because the start of the working area is used by ChibiOS. */
                          ntp + sizeof(thread_t) + 32,
                          5, /* 32 bytes */
                          AP_NO_NO, /* no permission */
                          false);
+    chSysUnlockFromISR();
 
 }

--- a/src/main.c
+++ b/src/main.c
@@ -200,3 +200,10 @@ int main(void) {
     }
 }
 
+uintptr_t __stack_chk_guard = 0xdeadbeef;
+
+void __stack_chk_fail(void)
+{
+    chSysHalt("Stack smashing detected");
+}
+


### PR DESCRIPTION
This PR implements two useful memory safety protections:

1. The end of the task stacks are now protected by an MPU region to prevent task stack overflow.
2. The project uses GCC's stack smashing protection to detect local variable overflow.

It builds but I haven't tested it on hardware yet, so maybe it crashes. Can somebody with a board test it an report ? @nuft maybe ?