### PR TITLE
Install CVRA packager via pip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "ChibiOS"]
 	path = ChibiOS
 	url = https://github.com/cvra/ChibiOS
-[submodule "packager"]
-	path = packager
-	url = https://github.com/cvra/packager.git
 [submodule "lwip"]
 	path = lwip
 	url = https://github.com/cvra/lwip

--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ It runs on an Olimex E407 board, and communicates with the embedded PC via Ether
 
 # Quickstart
 This requires a working ARM toolchain and OpenOCD.
-By default it assumes you are using a BusBlaster V2.
-You can change this in oocd.cfg.
+It also requires CVRA's packager system, you can install it by running `sudo pip3 install cvra-packager==1.0.0`.
+By default it assumes you are using a ST-Link V2.
+You can change this in the Makefile.
 
 ```
     git submodule init
     git submodule update
 
-    ./packager/packager.py
+    packager
     make dsdlc
     make
     make flash
 ```
 
-Now the board should be pingable at 192.168.0.20.
+Now the board should be pingable at 192.168.3.20.
 
 # Kernel panics
 If there is a kernel panic, the board will reboot and turn on a green led.

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ git submodule summary | sed -e "s/\x1b\[.\{1,5\}m//g" # the regex removes color
 printf "\033[0m"
 
 printf "\033[1;34m\n%s\033[0m\n" "Running packager"
-python packager/packager.py
+packager
 
 make dsdlc
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -16,7 +16,7 @@ export CFLAGS="$CFLAGS -I $HOME/cpputest/include/"
 export CXXFLAGS="$CXXFLAGS -I $HOME/cpputest/include/"
 export LDFLAGS="$CXXFLAGS -L $HOME/cpputest/lib/"
 
-packager/packager.py
+packager
 
 case $BUILD_TYPE in
     tests)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,7 +8,7 @@ source env/bin/activate
 python --version
 wget https://bootstrap.pypa.io/get-pip.py
 python get-pip.py
-pip install -r packager/requirements.txt
+pip install cvra-packager==1.0.0
 
 pushd uavcan/libuavcan/dsdl_compiler/pyuavcan/
 python setup.py install


### PR DESCRIPTION
I know this is kind of controversial in the team but I would like to start using `pip` instead of submodules to install the tools we use at the club. I feel like it has a better support for versions and it is also more comfortable to use (being able to run the command from any directory rocks).

What do you guys think ? @Stapelzeiger @nuft @froj @SyrianSpock 